### PR TITLE
Do not scan for installed programs and just exit after installing.

### DIFF
--- a/src/bat/inswin31.bat
+++ b/src/bat/inswin31.bat
@@ -1,4 +1,19 @@
 @echo off
 unix -s dosemu-preinstallwin31
+if errorlevel 1 goto faildownload
 if exist %USERDRV%:\inst\win31\setup.exe %USERDRV%:\inst\win31\setup.exe /h:f:\win31\dosemu.shh
+if errorlevel 1 goto failwinsetup
 if exist %USERDRV%:\windows\nul path %PATH%;%USERDRV%:\windows
+echo Windows 3.1 was successfully installed.
+echo Type "win" and press enter to start Windows.
+goto end
+
+:faildownload
+echo There was an error downloading the required files to install Windows 3.1.
+goto end
+
+:failwinsetup
+echo The Windows 3.1 Setup program did not complete successfully.
+goto end
+
+:end

--- a/src/dosemu.shh
+++ b/src/dosemu.shh
@@ -116,8 +116,8 @@ c:\windows
 ; If you specify both "setupapps" and "autosetupapps", all applications on 
 ; your hard disk will be set up.
 ;
-setupapps                  ; Setup applications already on hard disk
-autosetupapps              ; Set up all applications on hard disk
+;setupapps                  ; Setup applications already on hard disk
+;autosetupapps              ; Set up all applications on hard disk
 ;tutorial                   ; Start Windows Tutorial at the end of Setup
 
 [printers]
@@ -170,5 +170,5 @@ autosetupapps              ; Set up all applications on hard disk
 ; reboot option is not valid. Setup will exit to DOS instead of rebooting
 ; your system.
 ;
-;configfiles = save
-;endopt      = restart
+configfiles = save
+endopt      = exit


### PR DESCRIPTION
This fully automates the installation procedure.

This addresses the comments so that there's no risk of very long scans and generating program icons in Program Manager which are usually incorrect anyhow. Also the question at the end is removed and one gets the prompt straight away now with a message suggesting to type `win` to start Windows.