### PR TITLE
Use correct encoding with setup info files

### DIFF
--- a/src/dosemu-patchwin31inst
+++ b/src/dosemu-patchwin31inst
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import codecs
 import fileinput
 import os
 import shutil
@@ -13,8 +14,8 @@ def print_cr(string):
 def is_comment(line):
     return line.lstrip().startswith(';')
 
-def patch_file(file, append_after, new_string):
-    with open(file) as ofile:
+def patch_file(file, encoding, append_after, new_string):
+    with codecs.open(file, encoding=encoding) as ofile:
         if append_after not in ofile.read():
             ofile.close()
             with open(file, 'a') as ofile:
@@ -22,10 +23,10 @@ def patch_file(file, append_after, new_string):
                 ofile.write(append_after)
                 ofile.write('\r\n')
         ofile.close()
-    with open(file) as ofile:
+    with codecs.open(file, encoding=encoding) as ofile:
         if new_string not in ofile.read():
             ofile.close()
-            for line in fileinput.input(file, inplace=True):
+            for line in fileinput.input(file, encoding=encoding, inplace=True):
                 if not is_comment(line) and append_after in line:
                     print_cr(line.rstrip())
                     print_cr(new_string)
@@ -37,7 +38,7 @@ sections_to_copy = ['[display]', '[oemdisks]', '[pointing.device]']
 def parse_oemsetup_file(file):
     oemsetup_data = []
     copy_disks_section = False
-    with open(file) as ofile:
+    with codecs.open(file, encoding='cp437') as ofile:
         if '[oemdisks]' not in ofile.read():
             copy_disks_section = True
         ofile.seek(0)
@@ -70,6 +71,7 @@ There is a special option to add a DOSEMU2 machine type.
 Repeating this script should not have averse effects (idempotent).""")
 parser.add_argument("-s", "--source",      help="Path to driver directory", type=str)
 parser.add_argument("-d", "--destination", help="Path to Windows 3.1 installation files", type=str)
+parser.add_argument("-c", "--codepage",    help="Codepage used by Windows 3.1 installation files", type=str)
 
 args = parser.parse_args()
 
@@ -89,7 +91,7 @@ if not Path(setupinfo_file).exists():
 
 driver_data = parse_oemsetup_file(driverinfo_file)
 for entry in driver_data:
-    patch_file(setupinfo_file, entry[0], entry[1])
+    patch_file(setupinfo_file, args.codepage, entry[0], entry[1])
 
 EXTENSION_LIST = [ '386', 'drv', 'exe' ]
 for extension in EXTENSION_LIST:

--- a/src/dosemu-preinstallwin31
+++ b/src/dosemu-preinstallwin31
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -18,6 +19,8 @@ SOURCES = [
         'type': 'windows',
         'name': 'win31',
         'short_name': 'win31',
+        'lang': 'en',
+        'codepage': 'cp437',
         'urls':
             [
                 'http://archive.org/download/IBM_PC_Compatibles_TOSEC_2012_04_23/IBM_PC_Compatibles_TOSEC_2012_04_23.zip/IBM%20PC%20Compatibles%20%5BTOSEC%5D%2FIBM%20PC%20Compatibles%20-%20Operating%20Systems%20-%20%5BIMA%5D%20%28TOSEC-v2011-01-06_CM%29%2FMicrosoft%20Windows%20v3.1%20%281992%29%28Microsoft%29%28Disk%201%20of%206%29.zip'
@@ -57,10 +60,20 @@ SOURCES = [
     }
     ]
 
+SYSLANG = re.findall(r'([a-z][a-z]+)_.+', os.environ['LANG'])[0]
+WINLANG = 'en'
+WINCODEPAGE = '437'
+for source in SOURCES:
+    if source.get('lang') == SYSLANG:
+        WINLANG = source.get('lang')
+        WINCODEPAGE = source.get('codepage')
+
 target = '';
 target_dir = '';
 for source in SOURCES:
     if source.get('type') == 'windows':
+        if source.get('lang') != WINLANG:
+            continue
         target = source.get('short_name')
         target_dir = os.path.join(ROOT_DIR, 'inst', target)
         destination_dir = target_dir
@@ -90,6 +103,9 @@ for source in SOURCES:
         patch_command.append(destination_dir)
         patch_command.append('-d')
         patch_command.append(target_dir)
+        patch_command.append('-c')
+        patch_command.append(WINCODEPAGE)
+        result = subprocess.run(patch_command).returncode
         if (subprocess.run(patch_command).returncode != 0):
             print('Driver error')
             sys.exit(1)


### PR DESCRIPTION
I have been changing the code quite a bit to support different versions of Windows 3.1 that use different languages. Not all of them are working yet, but it seems a good idea to already create PRs for some ground work.

This change is necessary because the existing code trips over when it encounters non-ASCII characters in `setup.inf`. The encoding used by Python when not specifying it like this is UTF-8. The English version of Windows has a `setup.inf` which uses ASCII characters exclusively and this works, but the moment it needs to handle another language version, the code crashes because it comes across bytes that cannot be interpreted as proper UTF-8.

The encoding of `setup.inf` depends on the language of the version of Windows, so this needs to be specified.