### PR TITLE
Fix issues in the patching logic, get rid of odd Trident driver

### DIFF
--- a/src/dosemu-downloader
+++ b/src/dosemu-downloader
@@ -18,8 +18,16 @@ from tqdm import tqdm
 TMP_DIR = os.path.join('/tmp', os.path.basename(sys.argv[0]) + '-' + os.environ['USER'] + '-' + str(os.getpid()))
 CACHE_DIR = os.path.join(os.environ['HOME'], '.cache', 'dosemu')
 
+eight_dot_three_matcher = re.compile(r'^\S{1,8}(\.\S{1,3})?$')
+
+def is_eight_dot_three_filename(filename):
+    return eight_dot_three_matcher.match(filename)
+
 def download_file(source, destination_directory):
-    destination_file = os.path.join(destination_directory, urllib.parse.unquote(source.split("/")[-1]))
+    destination_file = urllib.parse.unquote(source.split("/")[-1])
+    if (is_eight_dot_three_filename(destination_file)):
+        destination_file = destination_file.lower()
+    destination_file = os.path.join(destination_directory, destination_file)
     if not Path(destination_file).is_file():
         print('Downloading ' + source + '...')
         with urllib.request.urlopen(source) as response, open(destination_file, 'wb') as f:

--- a/src/dosemu-patchwin31inst
+++ b/src/dosemu-patchwin31inst
@@ -18,20 +18,40 @@ def patch_file(file, encoding, append_after, new_string):
     with codecs.open(file, encoding=encoding) as ofile:
         if append_after not in ofile.read():
             ofile.close()
-            with open(file, 'a') as ofile:
+            with codecs.open(file, 'a', encoding=encoding) as ofile:
                 ofile.write('\r\n')
                 ofile.write(append_after)
                 ofile.write('\r\n')
         ofile.close()
-    with codecs.open(file, encoding=encoding) as ofile:
-        if new_string not in ofile.read():
-            ofile.close()
-            for line in fileinput.input(file, encoding=encoding, inplace=True):
-                if not is_comment(line) and append_after in line:
+    line_injected = False
+    with fileinput.input(file, encoding=encoding, inplace=True) as ofile:
+        in_section = False
+        found_line = False
+        inject_line = False
+        for line in ofile:
+            if not in_section and line.strip() == append_after:
+                in_section = True
+            if in_section:
+                if line == new_string:
+                    # the line is already there
+                    found_line = True
+                if line.strip() != append_after and line.startswith('[') and not found_line:
+                    # this is the next section and we did not find the line
+                    inject_line = True
+            if inject_line:
+                print_cr(new_string)
+                print_cr(line.rstrip())
+                in_section = False
+                inject_line = False
+                line_injected = True
+            else:
+                # stripping the comments avoids that the file becomes too big for setup to load (>64k)
+                if not is_comment(line):
                     print_cr(line.rstrip())
-                    print_cr(new_string)
-                else:
-                    print_cr(line.rstrip())
+    if not line_injected:
+        with codecs.open(file, 'a', encoding=encoding) as ofile:
+            ofile.write(new_string)
+            ofile.write('\r\n')
 
 sections_to_copy = ['[display]', '[oemdisks]', '[pointing.device]']
 

--- a/src/dosemu-preinstallwin31
+++ b/src/dosemu-preinstallwin31
@@ -28,7 +28,6 @@ SOURCES = [
     },
     {
         'type': 'integratableDriver',
-        'needsUnzipping': True,
         'name': 'w31drv-i33mouse',
         'short_name': 'mouse',
         'urls':
@@ -45,16 +44,6 @@ SOURCES = [
         'urls':
             [
                 'https://archive.org/download/SVGA_EXE/SVGA.EXE'
-            ]
-    },
-    {
-        'type': 'integratableDriver',
-        'name': 'w31drv-tvga',
-        'short_name': 'video2',
-        'urls':
-            [
-                'http://files.mpoli.fi/hardware/DISPLAY/TRIDENT/TVGAW31A.ZIP',
-                'http://files.mpoli.fi/hardware/DISPLAY/TRIDENT/TVGAW31B.ZIP'
             ]
     }
     ]
@@ -104,7 +93,6 @@ for source in SOURCES:
         patch_command.append(target_dir)
         patch_command.append('-c')
         patch_command.append(WINCODEPAGE)
-        result = subprocess.run(patch_command).returncode
         if (subprocess.run(patch_command).returncode != 0):
             print('Driver error')
             sys.exit(1)


### PR DESCRIPTION
The patching logic for `setup.inf` was broken. Lines that existed in another section would not be written. Now multiple sections can have identical lines. Also it was triggered twice.
Another issue was that sometimes `setup.inf` might become larger than 64kB. This will cause the installer to print a message that this file is damaged. Comment lines are stripped now which significantly decreases the size of the file. This is not a visible issue with the English version, but would become visible with Windows 3.1 versions in other languages as some of those ship a larger `setup.inf`.

The Trident driver has files that exist in both ZIP files and the current download logic trips over this. I Just removed that driver for now.

The download code will always lowercase 8.3 filenames now to match dosemu.