### PR TITLE
When the primary layout is Russian, switch it to American [fixes #15]

### DIFF
--- a/src/bat/stuffkey/w31skbsw.txt
+++ b/src/bat/stuffkey/w31skbsw.txt
@@ -1,2 +1,14 @@
 F24,10,85,"<Left Shift>+<Right Shift>"
+~1 F4,8,85,"Основная:         Русская"
+{IfTrue}
+{Up}
+{Up}
+{Up}
+{Up}
+{Cr}
+F6,19,85,"Американская"
+{Cr}
+F24,10,85,"<Left Shift>+<Right Shift>"
+{Cr}
+{Else}
 {Cr}


### PR DESCRIPTION
Tested with both the Russian and Central and Eastern European edition of Windows 3.1.

Note that this file needs to be read as CP866 to view the strings correctly.